### PR TITLE
[EVG-12011] Global Template | Google Analytics Segment Push

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,15 @@ This global template displays a popup when a user intends to exit the page.
 7. Style (Dark text on light background, light text on dark background)
 8. Background Image URL
     - "https://cdn.evergage.com/evergage-content/cumulus/cumulus_growth.jpg"
+
+
+### Google Analytics Segment Push
+
+This global template lets you push one or more segments to the specified Google Analytics dimensions. Any and all segments that match user membership will be set to the Google Analytics dimension provided.
+
+#### Configuration:
+![Google Analytics Segment Push Configuration](https://user-images.githubusercontent.com/32201252/91138016-a6a1e500-e663-11ea-8894-48c98578e4ab.png)
+
+1. Google Analytics Dimension
+    - Ex: "dimension 27"
+2. Segment Picker (multi-option)

--- a/google-analytics-segment-push/client.js
+++ b/google-analytics-segment-push/client.js
@@ -10,7 +10,7 @@
       const gaMapping = context.gaMapping;
       for (const dimension in gaMapping) {
         const matchedSegments = gaMapping[dimension].join("|");
-        ga('set', dimension, matchedSegments);
+        window.ga('set', dimension, matchedSegments);
       }
   }
 
@@ -19,7 +19,7 @@
    * @description Sends an event to Google Analytics with segments.
    */
   function sendGaDimensions(context) {
-      ga("send", {
+      window.ga("send", {
         hitType: "event",
         eventCategory: "Evergage",
         eventAction: "Set Segments",

--- a/google-analytics-segment-push/client.js
+++ b/google-analytics-segment-push/client.js
@@ -1,0 +1,52 @@
+(function() {
+
+  /**
+   * @function setGaDimension
+   * @description Sets one or more segments, for which users are members of, to each dimension. 
+   * The segment names will be concatenated into one pipe (|) delimited string (e.g. "Segment 1|Segment 2|Segment 3")
+   * when more than one segment per dimension are assigned.
+   */
+  function setGaDimension(context) {
+      const gaMapping = context.gaMapping;
+      for (const dimension in gaMapping) {
+        const matchedSegments = gaMapping[dimension].join("|");
+        ga('set', dimension, matchedSegments);
+      }
+  }
+
+  /**
+   * @function sendGaDimensions
+   * @description Sends an event to Google Analytics with segments.
+   */
+  function sendGaDimensions(context) {
+      ga("send", {
+        hitType: "event",
+        eventCategory: "Evergage",
+        eventAction: "Set Segments",
+        nonInteraction: true
+      });
+  }
+
+  function apply(context, template) {
+    if (window.ga && typeof window.ga === "function") {
+      setGaDimension(context);
+      sendGaDimensions(context);
+      Evergage.sendStat({campaignStats: [{control: false, experienceId: context.experience, stat: "Impression"}]});
+    }
+  }
+
+  function reset(context, template) {
+  
+  }
+  
+  function control() {
+    
+  }
+
+  registerTemplate({
+    apply: apply,
+    reset: reset,
+    control: control
+  });
+  
+})();

--- a/google-analytics-segment-push/evergage-template.json
+++ b/google-analytics-segment-push/evergage-template.json
@@ -1,0 +1,6 @@
+{
+  "name" : "Google Analytics Segment Push",
+  "description" : null,
+  "imageUrl" : null,
+  "category" : null
+}

--- a/google-analytics-segment-push/template.css
+++ b/google-analytics-segment-push/template.css
@@ -1,0 +1,1 @@
+/* Left intentionally blank. CSS is not needed for this template. */

--- a/google-analytics-segment-push/template.hbs
+++ b/google-analytics-segment-push/template.hbs
@@ -1,0 +1,17 @@
+{{!--
+    Global Template: Google Analytics Segment Push
+    
+    This global template lets you push one or more segments to the specified Google Analytics dimensions.     
+    Any and all segments that match user membership will be set to the Google Analytics dimension provided.
+    When a user matches more than one segment, the segment names will be concatenated into one pipe (|) 
+    delimited string (e.g. "Segment 1|Segment 2|Segment 3").
+
+    Requirements:
+    1) Ensure that the desired segments are available in the dataset.
+
+    Customizations:
+    1) Reconfigure the Google Analytics send method in Clientside as necessary.
+    2) Change the delimiter character from pipe ("|") to whatever is needed in Clientside.
+--}}
+
+<!-- HTML is not needed for this template -->

--- a/google-analytics-segment-push/template.ts
+++ b/google-analytics-segment-push/template.ts
@@ -1,0 +1,55 @@
+import { UserSegmentLookup, UserSegmentReference } from "common";
+
+export class GAMapping {
+    @title("Google Analytics Dimension")
+    @subtitle("e.g. dimension27")
+    gaDimension: string;
+
+    @title("Segment Picker")
+    @lookupOptions(() => new UserSegmentLookup())
+    segments: UserSegmentReference[]
+}
+
+export class GASegmentPushTemplate implements CampaignTemplateComponent {
+
+    @header("Why Use This Template")
+    @headerSubtitle(`
+        (1) Inform Google Analytics about visitors' interactions and
+        (2) transfer pre-defined segments to Google Analytics.
+    `)
+
+    readonly spacing = " ";
+
+    @header("How to Use This Template")
+    @headerSubtitle(`
+        This is a global template listing across any page. Choose your segment(s) from
+        Interaction Studio and map to a dimension in Google Analytics."
+    `)
+
+    @tabular()
+    @title("Map Segment to Google Analytics Dimensions")
+    tabularComplexField: GAMapping[];
+
+    run(context: CampaignComponentContext) {
+
+        let gaMapping = {};
+        this.tabularComplexField.forEach(mapping => {
+            if (('gaDimension' in mapping) && ('segments' in mapping)) {
+                const segments = [];
+                mapping.segments.forEach(segment => {
+                    const segmentJoinDate = context.user.getSegmentJoinDate(segment.id);
+                    if (segmentJoinDate) {
+                        segments.push(segment.label);
+                    }
+                })
+                if (mapping['gaDimension'] && segments.length) {
+                    gaMapping[mapping.gaDimension] = segments;
+                }
+            }
+        })
+
+        return {
+            gaMapping: gaMapping
+        };
+    }
+}

--- a/google-analytics-segment-push/template.ts
+++ b/google-analytics-segment-push/template.ts
@@ -1,6 +1,6 @@
 import { UserSegmentLookup, UserSegmentReference } from "common";
 
-export class GAMapping {
+export class GAConfig {
     @title("Google Analytics Dimension")
     @subtitle("e.g. dimension27")
     gaDimension: string;
@@ -22,13 +22,13 @@ export class GASegmentPushTemplate implements CampaignTemplateComponent {
 
     @header("How to Use This Template")
     @headerSubtitle(`
-        This is a global template listing across any page. Choose your segment(s) from
+        This is a global template meant to execute across any page. Choose your segment(s) from
         Interaction Studio and map to a dimension in Google Analytics."
     `)
 
     @tabular()
     @title("Map Segment to Google Analytics Dimensions")
-    tabularComplexField: GAMapping[];
+    tabularComplexField: GAConfig[];
 
     run(context: CampaignComponentContext) {
 


### PR DESCRIPTION
## Global Template: Google Analytics Segment Push

JIRA: https://help.evergage.com/browse/EVG-12011
Requirements doc: https://docs.google.com/document/d/1-PfGBHqnAwVSAR5Jn9FKT89gX-3b5RjHk-6Vc6xlNX8/edit?ts=5f3beaba#

This global template lets you push one or more segments to the specified Google Analytics dimensions. Any and all segments that match user membership will be set to the Google Analytics dimension provided. When a user matches more than one segment, the segment names will be concatenated into one pipe (|) delimited string (e.g. "Segment 1|Segment 2|Segment 3").

## Testing

### Things to check for:
* **Campaign stats tracking:** Does an impression stat fire upon page load?
* **Template-specific documentation**: Is there sufficient information for a template developer to use the global template and customize for their own use?

As for the Google Analytics event send portion, the approach is based on how we've done so in old gen campaigns, outlined here: https://doc.evergage.com/display/EKB/Pass+Attributes+to+Google+Analytics. I'm not sure how we should go about testing this since we're testing on a demo site and demo account/dataset (the nto site does load GA on their site, however). I'd appreciate any suggestions on this. 

Relevant resource: https://doc.evergage.com/pages/viewpage.action?spaceKey=EKBv1&title=Google+Analytics

## Demo

#### Template: 
- You can view the demo template in us:developer, **template name: [EVG-12011] Global - Google Analytics Segment Push**. 

#### Campaign: 
- You can view the demo campaign in us:developer, **campaign name: [EVG-12011] Global - Google Analytics Segment Push** 
- Sample nto test link: https://www.northerntrailoutfitters.com/default/homepage?evergageTestMessages=to67H
(Note: You will have to force inject the beacon: https://cdn.evergage.com/beacon/us/developer/scripts/evergage.min.js)

## Known issues
- In Serverside, I currently use a hack using `readonly spacing = " "` to make the `@header`/`@headerSubtitle` show up one after another. To address this issue, @avkieu is putting together a ticket for a markdown decorator.
- Currently, when you have multiple config input fields placed side by side horizontally (Due to using the [@tabular decorator](https://developer.evergage.com/config/decorators), the fields extend beyond the visible area of the sidebar. You would have to scroll to the right to see the fields. Although, I'm not sure if this actually is an "issue", since the `@tabular` decorator **is** meant to place each new config field side by side horizontally, making it impossible to keep all fields in a row visible within the sidebar (at its default size). Thoughts?

<img width="50%" alt="Screen Shot 2020-08-24 at 5 48 41 PM" src="https://user-images.githubusercontent.com/32201252/91210683-70478280-e6c2-11ea-8c8a-1c2419739867.png">
<img width="50%" alt="Screen Shot 2020-08-24 at 5 48 53 PM" src="https://user-images.githubusercontent.com/32201252/91210689-72a9dc80-e6c2-11ea-8f61-872c325b154f.png">