### PR TITLE
EVG-12955 | Exit Intent Popups: Remove mention of Serverside content zone in Handlebars comments

### DIFF
--- a/exit-intent-popup-with-email-capture/template.hbs
+++ b/exit-intent-popup-with-email-capture/template.hbs
@@ -6,7 +6,7 @@
     There are two default Styles: Dark text for lighter backgrounds or light text on darker backgrounds.
 
     Requirements:
-    1) Set the content zone in the Serverside Code to one that is defined in your Sitemap.
+    1) Set the content zone(s) to that defined in your Sitemap.
     2) Create a user attribute `emailAddress` to save the user's email to.
 
     Customizations:

--- a/exit-intent-popup/template.hbs
+++ b/exit-intent-popup/template.hbs
@@ -6,7 +6,7 @@
     There are two default Styles: Dark text for lighter backgrounds or light text on darker backgrounds.
 
     Requirements:
-    1) Set the content zone in the Serverside Code to one that is defined in your Sitemap.
+    1) Set the content zone(s) to that defined in your Sitemap.
 
     Customizations:
     1) As a best practice, set the content zone to "global_popup". See https://developer.evergage.com/websdk/contentzones


### PR DESCRIPTION
## JIRA

https://help.evergage.com/browse/EVG-12955

## Description

Remove mention of "content zone in the Serverside code..." from the _Exit Intent Popup global template_ and _Exit Intent Popup With Email Capture_ global template. I seem to have somehow added it back in there, but they should be removed, since content zones are not set via Serverside code anymore.

No need for testing. 