### PR TITLE
@W-8307466@ Prevent Campaigns from rendering 2+ times in same content zone

### DIFF
--- a/exit-intent-popup-with-email-capture/client.js
+++ b/exit-intent-popup-with-email-capture/client.js
@@ -69,10 +69,12 @@
          * https://developer.evergage.com/templates/display-utilities
          */
         return Evergage.DisplayUtils.bind(buildBindId(context)).pageExit(500).then(() => {
-            const html = template(context);
-            Evergage.cashDom("body").append(html);
-            setConfirmationPanel();
-            setDismissal(context);
+            if (Evergage.cashDom("#evg-exit-intent-popup").length === 0) {
+                const html = template(context);
+                Evergage.cashDom("body").append(html);
+                setConfirmationPanel();
+                setDismissal(context);
+            }
         });
     }
 

--- a/exit-intent-popup-with-email-capture/client.js
+++ b/exit-intent-popup-with-email-capture/client.js
@@ -48,13 +48,13 @@
      * template from the DOM.
      */
     function setDismissal(context) {
-        const dismissSelectors = [
-            "#evg-exit-intent-popup-email-capture .evg-overlay",
-            "#evg-exit-intent-popup-email-capture .evg-btn-dismissal",
-            "#evg-exit-intent-popup-email-capture .evg-opt-out-msg"
-        ];
+        const dismissSelectors = `
+            #evg-exit-intent-popup-email-capture .evg-overlay,
+            #evg-exit-intent-popup-email-capture .evg-btn-dismissal,
+            #evg-exit-intent-popup-email-capture .evg-opt-out-msg
+        `;
 
-        Evergage.cashDom(dismissSelectors.join(", ")).on("click", () => {
+        Evergage.cashDom(dismissSelectors).on("click", () => {
             Evergage.cashDom("#evg-exit-intent-popup-email-capture").remove();
         });
     }

--- a/exit-intent-popup-with-email-capture/client.js
+++ b/exit-intent-popup-with-email-capture/client.js
@@ -69,12 +69,12 @@
          * https://developer.evergage.com/templates/display-utilities
          */
         return Evergage.DisplayUtils.bind(buildBindId(context)).pageExit(500).then(() => {
-            if (Evergage.cashDom("#evg-exit-intent-popup").length === 0) {
-                const html = template(context);
-                Evergage.cashDom("body").append(html);
-                setConfirmationPanel();
-                setDismissal(context);
-            }
+            if (Evergage.cashDom("#evg-exit-intent-popup").length > 0) return;
+
+            const html = template(context);
+            Evergage.cashDom("body").append(html);
+            setConfirmationPanel();
+            setDismissal(context);
         });
     }
 

--- a/exit-intent-popup/client.js
+++ b/exit-intent-popup/client.js
@@ -35,11 +35,11 @@
          * https://developer.evergage.com/templates/display-utilities
          */
         return Evergage.DisplayUtils.bind(buildBindId(context)).pageExit(500).then(() => {
-            if (Evergage.cashDom("#evg-exit-intent-popup").length === 0) {
-                const html = template(context);
-                Evergage.cashDom("body").append(html);
-                setDismissal(context);
-            }
+            if (Evergage.cashDom("#evg-exit-intent-popup").length > 0) return;
+
+            const html = template(context);
+            Evergage.cashDom("body").append(html);
+            setDismissal(context);
         });
     }
 

--- a/exit-intent-popup/client.js
+++ b/exit-intent-popup/client.js
@@ -15,12 +15,12 @@
      * @description Adds click listener to the overlay and "X" button that removes the template from the DOM.
      */
     function setDismissal(context) {
-        const dismissSelectors = [
-            "#evg-exit-intent-popup .evg-overlay",
-            "#evg-exit-intent-popup .evg-btn-dismissal",
-        ];
+        const dismissSelectors = `
+            #evg-exit-intent-popup .evg-overlay,
+            #evg-exit-intent-popup .evg-btn-dismissal
+        `;
 
-        Evergage.cashDom(dismissSelectors.join(", ")).on("click", () => {
+        Evergage.cashDom(dismissSelectors).on("click", () => {
             Evergage.cashDom("#evg-exit-intent-popup").remove();
         });
     }

--- a/exit-intent-popup/client.js
+++ b/exit-intent-popup/client.js
@@ -35,9 +35,11 @@
          * https://developer.evergage.com/templates/display-utilities
          */
         return Evergage.DisplayUtils.bind(buildBindId(context)).pageExit(500).then(() => {
-            const html = template(context);
-            Evergage.cashDom("body").append(html);
-            setDismissal(context);
+            if (Evergage.cashDom("#evg-exit-intent-popup").length === 0) {
+                const html = template(context);
+                Evergage.cashDom("body").append(html);
+                setDismissal(context);
+            }
         });
     }
 

--- a/infobar-with-cta/client.js
+++ b/infobar-with-cta/client.js
@@ -6,9 +6,6 @@
      * @description Sets the position of the infobar via class assignments, based on content zone selected.
      */
     function setInfobarPosition(context) {
-        context.infobarClass = context.contentZone == "global_infobar_top_of_page"
-            ? "evg-infobar-top"
-            : "evg-infobar-bottom";
         if (context.infobarClass === "evg-infobar-top") {
             Evergage.cashDom("body").css({ "margin-bottom": "0", "margin-top": "2.5rem" });
         } else {
@@ -22,21 +19,27 @@
      * @description Adds click listener to the "X" button that removes the template from the DOM.
      */
     function setDismissal(context) {
-        Evergage.cashDom("#evg-infobar-with-cta .evg-btn-dismissal").on("click", () => {
-            Evergage.cashDom("#evg-infobar-with-cta").remove();
+        Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass} .evg-btn-dismissal`).on("click", () => {
+            Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
             Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
         });
     }
 
     function apply(context, template) {
-        setInfobarPosition(context);
-        const html = template(context);
-        Evergage.cashDom("body").append(html);
-        setDismissal(context);
+        context.infobarClass = context.contentZone == "global_infobar_top_of_page"
+            ? "evg-infobar-top"
+            : "evg-infobar-bottom";
+
+        if (Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).length === 0) {
+            setInfobarPosition(context);
+            const html = template(context);
+            Evergage.cashDom("body").append(html);
+            setDismissal(context);
+        }
     }
 
     function reset(context, template) {
-        Evergage.cashDom("#evg-infobar-with-cta").remove();
+        Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
         Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
     }
 

--- a/infobar-with-cta/client.js
+++ b/infobar-with-cta/client.js
@@ -30,12 +30,12 @@
             ? "evg-infobar-top"
             : "evg-infobar-bottom";
 
-        if (Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).length === 0) {
-            setInfobarPosition(context);
-            const html = template(context);
-            Evergage.cashDom("body").append(html);
-            setDismissal(context);
-        }
+        if (Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).length > 0) return;
+
+        setInfobarPosition(context);
+        const html = template(context);
+        Evergage.cashDom("body").append(html);
+        setDismissal(context);
     }
 
     function reset(context, template) {


### PR DESCRIPTION
# Description

This PR ensures that the following templates check for themselves before injecting themselves on the page:
- Exit-Intent Pop-Up
- Exit-Intent Pop-Up with Email Capture
- Infobar with CTA

Also in the case of one’s using display utils, be sure to use the “bind” methods, so multiple queued messages will unbind the previously bound message.

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008AbEEIA0/view

## How to test

Note: I've set up click listeners on the `body` to send an event with the content zones used for each Template for testing.

#### Infobar with CTA
**Campaigns:**
- W-8307466 | Global Infobar Test
_shouldn't display:_
- W-8307466 | Global Infobar Test - Top Dupe

#### Exit-Intent Pop-Up
**Campaigns:**
Test Page: https://www.northerntrailoutfitters.com/default/shoes
- W-8307466 | Global Exit-Intent Popup Test (SHOES)
_shouldn't display:_
- W-8307466 | Global Exit-Intent Popup Test - Same CZ Dupe (SHOES)
- W-8307466 | Global Exit-Intent Popup Test - Diff CZ Dupe (SHOES)

Test Page: https://www.northerntrailoutfitters.com/default/men%E2%80%99s-bridgeton-chukka-boots-1050127AIW.html
- W-8307466 | PDP Exit-Intent Popup Test
_shouldn't display_
- W-8307466 | PDP Exit-Intent Popup Test - Same CZ Dupe
- W-8307466 | PDP Exit-Intent Popup Test - Diff CZ Dupe

#### Exit-Intent Pop-Up with Email Capture 
**Campaigns:**
- W-8307466 | Exit Intent Pop-Up with Email Capture
_shouldn't display_
- W-8307466 | Exit Intent Pop-Up with Email Capture - Same CZ Dupe
- W-8307466 | Exit Intent Pop-Up with Email Capture - Diff CZ Dupe