### PR TITLE
Add PR template for GitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ _Note: you will need to force the SDK using this URL: SDK_URL_
 <!-- Steps for how to test your changes -->
 
 ### Things to check for:
-* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST (see [template snippet](https://gist.github.com/nriserEG/fcfe7ab7e04d51dbf9cb19fc0476d474).)
+* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST (see [template snippet](https://gist.github.com/nriserEG/fcfe7ab7e04d51dbf9cb19fc0476d474))
 * **Mobile/smaller screen responsiveness:** Does the Template generally look good on smaller screens?
 * **WCAG compliant:** Does the template contain ARIA attributes and/or use semantic elements for web accessibility? You can use the [WAVE Chrome extension tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) for a quick check.
 * **Template-specific documentation**: Is there sufficient information for a Template Developer to use the Global Template and customize it for their own use?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+# Description
+
+<!-- A brief description of changes in this PR -->
+
+## Related Issues/Tickets
+
+<!--
+    Link to any and all tickets from GUS, Org62,
+    Zendesk, etc. which are addressed in this PR
+-->
+
+## How to test
+
+#### Template:
+- You can view the demo template in account:dataset, **template name: TEMPLATE_NAME**.
+
+#### Campaign:
+- You can view the demo campaign using this template in account:dataset, **campaign name: CAMPAIGN_NAME**
+_Note: you will need to force the SDK using this URL: SDK_URL_
+
+<!-- Steps for how to test your changes -->
+
+### Things to check for:
+* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST
+* **Mobile/smaller screen responsiveness:** Does the Template generally look good on smaller screens?
+* **WCAG compliant:** Does the template contain ARIA attributes and/or use semantic elements for web accessibility?
+** You can use the WAVE Chrome extension tool https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh for a quick check.
+* **Template-specific documentation**: Is there sufficient information for a Template Developer to use the Global Template and customize it for their own use?
+* **FlickerDefender**: Is the page being fully hidden until the following page?
+* **Campaign stats tracking:** Do impression stats and click stats fire for both the Control and Test experience?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,10 +21,9 @@ _Note: you will need to force the SDK using this URL: SDK_URL_
 <!-- Steps for how to test your changes -->
 
 ### Things to check for:
-* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST
+* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST (see [template snippet](https://gist.github.com/nriserEG/fcfe7ab7e04d51dbf9cb19fc0476d474).)
 * **Mobile/smaller screen responsiveness:** Does the Template generally look good on smaller screens?
-* **WCAG compliant:** Does the template contain ARIA attributes and/or use semantic elements for web accessibility?
-** You can use the WAVE Chrome extension tool https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh for a quick check.
+* **WCAG compliant:** Does the template contain ARIA attributes and/or use semantic elements for web accessibility? You can use the [WAVE Chrome extension tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) for a quick check.
 * **Template-specific documentation**: Is there sufficient information for a Template Developer to use the Global Template and customize it for their own use?
 * **FlickerDefender**: Is the page being fully hidden until the following page?
 * **Campaign stats tracking:** Do impression stats and click stats fire for both the Control and Test experience?


### PR DESCRIPTION
# Description

Adds a simple PR template, which follows [a naming convention supported by GitHub](https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository). The result is that the texarea field with pre-populate with something like the following whenever someone creates a PR:
![Screen Shot 2020-05-15 at 4 22 04 PM](https://user-images.githubusercontent.com/50626880/82094886-eacc3380-96cb-11ea-8e7f-848c0cb0a7a3.png)

## How to test

- Well, you can't here until this is merged into `master`. However, we have something similar in the [customer repo](https://github.com/evergage/evergage-customer) so you could see how it works by creating a PR there.

#### Similar PRs
https://github.com/evergage/evergage-customer/pull/638
https://github.com/evergage/evergage-developer-docs-static/pull/17


## Note
I've added a few things that seem like they'd be relevant, based on some of other recent PRs in this repo, but please let me know if you think anything should be added/removed/etc.