### PR TITLE
@W-9043924@ BUG | Fix control tracking for Redirect Global Template

### DIFF
--- a/redirect/client.js
+++ b/redirect/client.js
@@ -41,18 +41,14 @@
     }
 
     function control(context) {
-        const { campaign, experience } = context;
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone) || 'body';
-        Evergage.DisplayUtils.bind(`${campaign}:${experience}`).pageElementLoaded(contentZoneSelector).then(element => {
-            Evergage.sendStat({
-                campaignStats: [
-                    {
-                        control: true,
-                        experienceId: context.experience,
-                        stat: "Impression"
-                    }
-                ]
-            });
+        Evergage.sendStat({
+            campaignStats: [
+                {
+                    control: true,
+                    experienceId: context.experience,
+                    stat: "Impression"
+                }
+            ]
         });
     }
 

--- a/redirect/client.js
+++ b/redirect/client.js
@@ -40,8 +40,20 @@
 
     }
 
-    function control() {
-
+    function control(context) {
+        const { campaign, experience } = context;
+        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone) || 'body';
+        Evergage.DisplayUtils.bind(`${campaign}:${experience}`).pageElementLoaded(contentZoneSelector).then(element => {
+            Evergage.sendStat({
+                campaignStats: [
+                    {
+                        control: true,
+                        experienceId: context.experience,
+                        stat: "Impression"
+                    }
+                ]
+            });
+        });
     }
 
     registerTemplate({


### PR DESCRIPTION
# Description

This PR ensures that control impressions are tracked for correctly in the Redirect template.

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH0000008v5YYAQ/view

## How to test
Account: `training`
Dataset: `amask`

**Campaign**: BUG W-9043924 | Redirect
**Template**: BUG W-9043924 | Redirect Test

NOTE: For ease of testing, I've left console.log statements in each of the Templates, which print the first text input field followed by the experience ID, since that is used in the `msreceiver`.