### PR TITLE
@W-9283572@ BUG | Exit Intent Pop-ups returning control stat on page load

### DIFF
--- a/exit-intent-popup-with-email-capture/client.js
+++ b/exit-intent-popup-with-email-capture/client.js
@@ -90,13 +90,12 @@
     }
 
     function control(context) {
-        return context.contentZone
-            && Evergage.DisplayUtils
-                .bind(buildBindId(context))
-                .pageExit(pageExitMillis)
-                .then(() => {
-                    return true;
-                });
+        return Evergage.DisplayUtils
+            .bind(buildBindId(context))
+            .pageExit(pageExitMillis)
+            .then(() => {
+                if (context.contentZone) return true;
+            });
     }
 
     registerTemplate({

--- a/exit-intent-popup/client.js
+++ b/exit-intent-popup/client.js
@@ -55,13 +55,12 @@
     }
 
     function control(context) {
-        return context.contentZone
-            && Evergage.DisplayUtils
-                .bind(buildBindId(context))
-                .pageExit(pageExitMillis)
-                .then(() => {
-                    return true;
-                });
+        return Evergage.DisplayUtils
+            .bind(buildBindId(context))
+            .pageExit(pageExitMillis)
+            .then(() => {
+                if (context.contentZone) return true;
+            });
     }
 
     registerTemplate({


### PR DESCRIPTION
# Description

For the `control` function in both of the "Exit Intent" global templates, the `contentZone` checks have been moved inside of `pageExit` resolution. The way those functions are currently written, an impression stat would be sent immediately for the control group if `context.contentZone` returned a falsey value.

An easy example of how this could currently happen:
- customer clones pop-up Template and doesn't add a content zone at first
- then they create a Campaign and use that Template
- later, they add a content zone to the Template but do not update the use of the Template in that Campaign

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000M6uPYAS/view

## How to test
Account: `training`
Dataset: `amask`
SDK URL: https://cdn.evgnet.com/beacon/training/amask/scripts/evergage.min.js

**Campaign**: [W-9043924] Exit Intent Pop-Up
**Template**: BUG [W-9043924] Exit Intent Pop-Up Test

_NOTE: For ease of testing, I've left `console.log` statements in the Template, which prints the first text input field followed by the current content zone from `context` and the experience ID, since that is used in the `msreceiver`._