### PR TITLE
W-9696080|Update Global Templates to Use Salesforce Namespace

### DIFF
--- a/banner-with-cta/client.js
+++ b/banner-with-cta/client.js
@@ -10,7 +10,7 @@
     }
 
     function apply(context, template) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
 
         /**
          * The pageElementLoaded method waits for the content zone to load into the DOM
@@ -22,28 +22,28 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
                 const html = template(context);
-                Evergage.cashDom(element).html(html);
+                Salesforce.cashDom(element).html(html);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
             .remove();
     }
 
     function control(context) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
-        return Evergage.DisplayUtils
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
-                Evergage.cashDom(element).attr({
+                Salesforce.cashDom(element).attr({
                     "data-evg-campaign-id": context.campaign,
                     "data-evg-experience-id": context.experience,
                     "data-evg-user-group": context.userGroup

--- a/einstein-content-recommendations/client.js
+++ b/einstein-content-recommendations/client.js
@@ -10,7 +10,7 @@
     }
 
     function apply(context, template) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
 
         /**
          * The pageElementLoaded method waits for the content zone to load into the DOM
@@ -22,28 +22,28 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
                 const html = template(context);
-                Evergage.cashDom(element).html(html);
+                Salesforce.cashDom(element).html(html);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
             .remove();
     }
 
     function control(context) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
-        return Evergage.DisplayUtils
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
-                Evergage.cashDom(element).attr({
+                Salesforce.cashDom(element).attr({
                     "data-evg-campaign-id": context.campaign,
                     "data-evg-experience-id": context.experience,
                     "data-evg-user-group": context.userGroup

--- a/einstein-decisions/client.js
+++ b/einstein-decisions/client.js
@@ -12,7 +12,7 @@
     function apply(context, template) {
         if (!context.contentZone || !context.imageUrl || !context.url) return;
 
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
 
         /**
          * The pageElementLoaded method waits for the content zone to load into the DOM
@@ -24,28 +24,28 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
                 const html = template(context);
-                Evergage.cashDom(element).html(html);
+                Salesforce.cashDom(element).html(html);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
             .remove();
     }
 
     function control(context) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
-        return Evergage.DisplayUtils
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
-                Evergage.cashDom(element).attr({
+                Salesforce.cashDom(element).attr({
                     "data-evg-campaign-id": context.campaign,
                     "data-evg-experience-id": context.experience,
                     "data-evg-user-group": context.userGroup

--- a/einstein-product-recommendations/client.js
+++ b/einstein-product-recommendations/client.js
@@ -10,7 +10,7 @@
     }
 
     function apply(context, template) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
 
         /**
          * The pageElementLoaded method waits for the content zone to load into the DOM
@@ -22,28 +22,28 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
                 const html = template(context);
-                Evergage.cashDom(element).html(html);
+                Salesforce.cashDom(element).html(html);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
             .remove();
     }
 
     function control(context) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
-        return Evergage.DisplayUtils
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
-                Evergage.cashDom(element).attr({
+                Salesforce.cashDom(element).attr({
                     "data-evg-campaign-id": context.campaign,
                     "data-evg-experience-id": context.experience,
                     "data-evg-user-group": context.userGroup

--- a/exit-intent-popup-with-email-capture/client.js
+++ b/exit-intent-popup-with-email-capture/client.js
@@ -18,17 +18,17 @@
      * an event to Interaction Studio to set the emailAddress attribute to the user email address.
      */
     function setConfirmationPanel() {
-        Evergage.cashDom("#evg-exit-intent-popup-email-capture .evg-cta").on("click", () => {
-            const emailAddress = Evergage.cashDom(".evg-form input[placeholder='Email']").val();
+        Salesforce.cashDom("#evg-exit-intent-popup-email-capture .evg-cta").on("click", () => {
+            const emailAddress = Salesforce.cashDom(".evg-form input[placeholder='Email']").val();
             const regex = RegExp(/^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]+)$/);
             if (emailAddress && regex.test(emailAddress)) {
-                Evergage.cashDom("#evg-exit-intent-popup-email-capture .evg-main-panel").addClass("evg-hide");
-                Evergage.cashDom("#evg-exit-intent-popup-email-capture .evg-confirm-panel").removeClass("evg-hide");
-                Evergage.cashDom(`
+                Salesforce.cashDom("#evg-exit-intent-popup-email-capture .evg-main-panel").addClass("evg-hide");
+                Salesforce.cashDom("#evg-exit-intent-popup-email-capture .evg-confirm-panel").removeClass("evg-hide");
+                Salesforce.cashDom(`
                     #evg-exit-intent-popup-email-capture .evg-overlay,
                     #evg-exit-intent-popup-email-capture .evg-btn-dismissal
                 `).removeAttr("data-evg-dismissal");
-                Evergage.sendEvent({
+                Salesforce.sendEvent({
                     user: {
                         attributes: {
                             emailAddress: emailAddress
@@ -36,7 +36,7 @@
                     }
                 });
             } else {
-                Evergage.cashDom("#evg-exit-intent-popup-email-capture .evg-error-msg")
+                Salesforce.cashDom("#evg-exit-intent-popup-email-capture .evg-error-msg")
                     .removeClass("evg-hide")
                     .addClass("evg-error");
             }
@@ -56,8 +56,8 @@
             #evg-exit-intent-popup-email-capture .evg-opt-out-msg
         `;
 
-        Evergage.cashDom(dismissSelectors).on("click", () => {
-            Evergage.cashDom("#evg-exit-intent-popup-email-capture").remove();
+        Salesforce.cashDom(dismissSelectors).on("click", () => {
+            Salesforce.cashDom("#evg-exit-intent-popup-email-capture").remove();
         });
     }
 
@@ -71,26 +71,26 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageExit(pageExitMillis)
             .then(() => {
-                if (Evergage.cashDom("#evg-exit-intent-popup").length > 0) return;
+                if (Salesforce.cashDom("#evg-exit-intent-popup").length > 0) return;
 
                 const html = template(context);
-                Evergage.cashDom("body").append(html);
+                Salesforce.cashDom("body").append(html);
                 setConfirmationPanel();
                 setDismissal(context);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom("#evg-exit-intent-popup-email-capture").remove();
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom("#evg-exit-intent-popup-email-capture").remove();
     }
 
     function control(context) {
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageExit(pageExitMillis)
             .then(() => {

--- a/exit-intent-popup/client.js
+++ b/exit-intent-popup/client.js
@@ -22,8 +22,8 @@
             #evg-exit-intent-popup .evg-btn-dismissal
         `;
 
-        Evergage.cashDom(dismissSelectors).on("click", () => {
-            Evergage.cashDom("#evg-exit-intent-popup").remove();
+        Salesforce.cashDom(dismissSelectors).on("click", () => {
+            Salesforce.cashDom("#evg-exit-intent-popup").remove();
         });
     }
 
@@ -37,25 +37,25 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageExit(pageExitMillis)
             .then(() => {
-                if (Evergage.cashDom("#evg-exit-intent-popup").length > 0) return;
+                if (Salesforce.cashDom("#evg-exit-intent-popup").length > 0) return;
 
                 const html = template(context);
-                Evergage.cashDom("body").append(html);
+                Salesforce.cashDom("body").append(html);
                 setDismissal(context);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom("#evg-exit-intent-popup").remove();
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom("#evg-exit-intent-popup").remove();
     }
 
     function control(context) {
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageExit(pageExitMillis)
             .then(() => {

--- a/google-analytics-segment-push/client.js
+++ b/google-analytics-segment-push/client.js
@@ -33,7 +33,7 @@
         if (window.ga && typeof window.ga === "function") {
             setGaDimension(context);
             sendGaDimensions(context);
-            Evergage.sendStat({
+            Salesforce.sendStat({
                 campaignStats: [
                     {
                         control: false,

--- a/infobar-with-cta/client.js
+++ b/infobar-with-cta/client.js
@@ -7,9 +7,9 @@
      */
     function setInfobarPosition(context) {
         if (context.infobarClass === "evg-infobar-top") {
-            Evergage.cashDom("body").css({ "margin-bottom": "0", "margin-top": "2.5rem" });
+            Salesforce.cashDom("body").css({ "margin-bottom": "0", "margin-top": "2.5rem" });
         } else {
-            Evergage.cashDom("body").css({ "margin-bottom": "2.5rem", "margin-top": "0" });
+            Salesforce.cashDom("body").css({ "margin-bottom": "2.5rem", "margin-top": "0" });
         }
     }
 
@@ -19,9 +19,9 @@
      * @description Add click listener to the "X" button that removes the template from the DOM.
      */
     function setDismissal(context) {
-        Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass} .evg-btn-dismissal`).on("click", () => {
-            Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
-            Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
+        Salesforce.cashDom(`#evg-infobar-with-cta.${context.infobarClass} .evg-btn-dismissal`).on("click", () => {
+            Salesforce.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
+            Salesforce.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
         });
     }
 
@@ -32,17 +32,17 @@
             ? "evg-infobar-top"
             : "evg-infobar-bottom";
 
-        if (Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).length > 0) return;
+        if (Salesforce.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).length > 0) return;
 
         setInfobarPosition(context);
         const html = template(context);
-        Evergage.cashDom("body").append(html);
+        Salesforce.cashDom("body").append(html);
         setDismissal(context);
     }
 
     function reset(context, template) {
-        Evergage.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
-        Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
+        Salesforce.cashDom(`#evg-infobar-with-cta.${context.infobarClass}`).remove();
+        Salesforce.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
     }
 
     function control(context) {

--- a/infobar-with-user-attribute-and-cta/client.js
+++ b/infobar-with-user-attribute-and-cta/client.js
@@ -7,9 +7,9 @@
      */
     function setInfobarPosition(context) {
         if (context.infobarClass === "evg-infobar-top") {
-            Evergage.cashDom("body").css({ "margin-bottom": "0", "margin-top": "2.5rem" });
+            Salesforce.cashDom("body").css({ "margin-bottom": "0", "margin-top": "2.5rem" });
         } else {
-            Evergage.cashDom("body").css({ "margin-bottom": "2.5rem", "margin-top": "0" });
+            Salesforce.cashDom("body").css({ "margin-bottom": "2.5rem", "margin-top": "0" });
         }
     }
 
@@ -19,9 +19,9 @@
      * @description Adds click listener to the "X" button that removes the template from the DOM.
      */
     function setDismissal(context) {
-        Evergage.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass} .evg-btn-dismissal`).on("click", () => {
-            Evergage.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).remove();
-            Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
+        Salesforce.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass} .evg-btn-dismissal`).on("click", () => {
+            Salesforce.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).remove();
+            Salesforce.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
         });
     }
 
@@ -32,20 +32,20 @@
             ? "evg-infobar-top"
             : "evg-infobar-bottom";
 
-        if (Evergage.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).length > 0) return;
+        if (Salesforce.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).length > 0) return;
 
         const { preAttrMessageText, userAttr, postAttrMessageText } = context;
         context.messageText = `${preAttrMessageText}${userAttr}${postAttrMessageText}`;
 
         setInfobarPosition(context);
         const html = template(context);
-        Evergage.cashDom("body").append(html);
+        Salesforce.cashDom("body").append(html);
         setDismissal(context);
     }
 
     function reset(context, template) {
-        Evergage.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).remove();
-        Evergage.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
+        Salesforce.cashDom(`#evg-infobar-with-user-attr.${context.infobarClass}`).remove();
+        Salesforce.cashDom("body").css({ "margin-top": "0", "margin-bottom": "0" });
     }
 
     function control(context) {

--- a/manual-promotion-selector/client.js
+++ b/manual-promotion-selector/client.js
@@ -12,9 +12,9 @@
     function apply(context, template) {
         if (!context.contentZone || !context.imageUrl || !context.url) return;
 
-        let contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
+        let contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
         if (!contentZoneSelector && context.selectedAsset) {
-            contentZoneSelector = Evergage.getContentZoneSelector(context.selectedAsset);
+            contentZoneSelector = Salesforce.getContentZoneSelector(context.selectedAsset);
         }
         /**
          * The pageElementLoaded method waits for the content zone to load into the DOM
@@ -26,28 +26,28 @@
          * Visit the Template Display Utilities documentation to learn more:
          * https://developer.evergage.com/campaign-development/web-templates/web-display-utilities
          */
-        return Evergage.DisplayUtils
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
                 const html = template(context);
-                Evergage.cashDom(element).html(html);
+                Salesforce.cashDom(element).html(html);
             });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom(`[data-evg-campaign-id="${context.campaign}"][data-evg-experience-id="${context.experience}"]`)
             .remove();
     }
 
     function control(context) {
-        const contentZoneSelector = Evergage.getContentZoneSelector(context.contentZone);
-        return Evergage.DisplayUtils
+        const contentZoneSelector = Salesforce.getContentZoneSelector(context.contentZone);
+        return Salesforce.DisplayUtils
             .bind(buildBindId(context))
             .pageElementLoaded(contentZoneSelector)
             .then((element) => {
-                Evergage.cashDom(element).attr({
+                Salesforce.cashDom(element).attr({
                     "data-evg-campaign-id": context.campaign,
                     "data-evg-experience-id": context.experience,
                     "data-evg-user-group": context.userGroup

--- a/redirect/client.js
+++ b/redirect/client.js
@@ -16,9 +16,9 @@
         }
 
         return new Promise((resolve, reject) => {
-            Evergage.cashDom("body").css("visibility", "hidden");
+            Salesforce.cashDom("body").css("visibility", "hidden");
 
-            Evergage.sendStat({
+            Salesforce.sendStat({
                 campaignStats: [
                     {
                         control: false,

--- a/slide-in-with-cta/client.js
+++ b/slide-in-with-cta/client.js
@@ -14,8 +14,8 @@
      * @description Add click listener to the "X" button that removes the template from the DOM.
      */
     function setDismissal() {
-        Evergage.cashDom("#evg-slide-in-with-cta .evg-btn-dismissal").on("click", () => {
-            Evergage.cashDom("#evg-slide-in-with-cta").remove();
+        Salesforce.cashDom("#evg-slide-in-with-cta .evg-btn-dismissal").on("click", () => {
+            Salesforce.cashDom("#evg-slide-in-with-cta").remove();
         });
     }
 
@@ -26,7 +26,7 @@
      */
     function handleTemplateContent({ context, template }) {
         const html = template(context);
-        Evergage.cashDom("body").append(html);
+        Salesforce.cashDom("body").append(html);
         setDismissal();
     }
 
@@ -51,7 +51,7 @@
                     }, triggerOptionsNumber);
                 });
             case "scrollDepth":
-                return Evergage.DisplayUtils
+                return Salesforce.DisplayUtils
                     .bind(buildBindId(context))
                     .pageScroll(triggerOptionsNumber)
                     .then((event) => {
@@ -60,7 +60,7 @@
                         handleTemplateContent({ context, template });
                     });
             case "inactivity":
-                return Evergage.DisplayUtils
+                return Salesforce.DisplayUtils
                     .bind(buildBindId(context))
                     .pageInactive(triggerOptionsNumber)
                     .then((event) => {
@@ -72,14 +72,14 @@
     }
 
     function apply(context, template) {
-        if (Evergage.cashDom("#evg-slide-in-with-cta").length > 0) return;
+        if (Salesforce.cashDom("#evg-slide-in-with-cta").length > 0) return;
 
         return handleTriggerEvent({ context, template });
     }
 
     function reset(context, template) {
-        Evergage.DisplayUtils.unbind(buildBindId(context));
-        Evergage.cashDom("#evg-slide-in-with-cta").remove();
+        Salesforce.DisplayUtils.unbind(buildBindId(context));
+        Salesforce.cashDom("#evg-slide-in-with-cta").remove();
     }
 
     function control(context) {


### PR DESCRIPTION
# Description

Update all functions in each global template to use the Salesforce namespace instead of the Evergage namespace

## Related Issues/Tickets

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000SxX7YAK/view)

## How to test

1. Check if each global template works as expected.
2. Test out the scenario where an existing customer w/ an existing Evergage namespace can still execute a global template that has the new Salesforce namespace.