### PR TITLE
W-10038044 - Bandit global template click tracking fix.

### DIFF
--- a/einstein-decisions/template.hbs
+++ b/einstein-decisions/template.hbs
@@ -18,7 +18,7 @@
 
 <div id="mcis-einstein-decisions" data-evg-campaign-id="{{campaign}}"
 data-evg-experience-id="{{experience}}" data-evg-user-group="{{userGroup}}">
-    <a class="mcis-promotion-link" href="{{url}}">
+    <a class="mcis-promotion-link" href="{{url}}" data-evg-item-id="{{id}}" data-evg-item-type="Promotion">
         <img class="mcis-promotion-img" src="{{imageUrl}}">
     </a>
 </div>

--- a/einstein-decisions/template.ts
+++ b/einstein-decisions/template.ts
@@ -98,8 +98,9 @@ export class EinsteinDecisionsTemplate implements CampaignTemplateComponent {
 
         const imageUrl: string = fetchImageUrl(promotion, context.contentZone);
         const url: string = promotion?.attributes?.url?.value ? promotion.attributes.url.value as string : "";
+        const id: string = promotion.id;
 
-        return { imageUrl, url };
+        return { imageUrl, url, id };
     }
 
 }


### PR DESCRIPTION
# Description

<!-- A brief description of changes in this PR -->
Fixes promotion stat tracking on the existing global template.
## Related Issues/Tickets
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000Ghyu9YAB/view

<!--
    Link to any and all tickets from GUS, Org62,
    Zendesk, etc. which are addressed in this PR
-->

## How to test

#### Template:
- Load it up in locally and make sure clicks on campaigns using this template send an msreceiver event with the proper `piks` array sent across.
![image](https://user-images.githubusercontent.com/8547933/137423739-443ab906-63f9-4812-af81-6202dbd0096d.png)
![image](https://user-images.githubusercontent.com/8547933/137423820-251165e1-490b-41ac-b212-42900a464d3c.png)


### Campaign:
Can test it out here:
https://www.northerntrailoutfitters.com/default/homepage?evergageTestMessages=x4cPN

Using this campaign:
https://eng3.devergage.com/ui/new-app/#/dataset/andrewtest/campaigns/edit

Which uses this template:
https://eng3.devergage.com/ui/new-app/#/dataset/andrewtest/templates/edit/1BwZc/?channel=Web

Just set the following settings in your chrome extension:
![image](https://user-images.githubusercontent.com/8547933/137425172-8220766a-706f-460f-aef1-4405f9158237.png)
