### PR TITLE
@W-10199073@ Bug | Control stats not sent correctly in Slide-In when using the timeOnPage trigger

### DIFF
--- a/slide-in-with-cta/client.js
+++ b/slide-in-with-cta/client.js
@@ -44,9 +44,9 @@
             case "timeOnPage":
                 return new Promise((resolve, reject) => {
                     setTimeout(() => {
-                        if (userGroup === "Control") return true;
-
-                        handleTemplateContent({ context, template });
+                        if (userGroup !== "Control") {
+                            handleTemplateContent({ context, template });
+                        }
                         resolve(true);
                     }, triggerOptionsNumber);
                 });


### PR DESCRIPTION
# Description

Fixes control stats tracking for the `timeOnPage` trigger option in the "Slide-In with CTA" template by resolving the Promise instead of just returning true for the control experience.

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000QVVThYAP/view

## How to test

#### Manual Testing
1. Create a clone of the Slide-In global template
2. Add the change from this PR
3. Use it in a Campaign and make sure that you select the `timeOnPage` trigger option
4. To "force" the control experience for the Campaign, set the control group percentage to 99%.
5. When viewing a page on a site where you qualify for that Campaign and are presented the control experience, you should see a campaign stat sent for it