### PR TITLE
@W-10784747@ Feature | Add 'Web' channel type to all web global templates

### DIFF
--- a/banner-with-cta/evergage-template.json
+++ b/banner-with-cta/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Banner with Call-To-Action",
-  "description" : null,
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Banner with Call-To-Action",
+    "description" : null,
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/einstein-content-recommendations/evergage-template.json
+++ b/einstein-content-recommendations/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Einstein Content Recommendations",
-  "description" : null,
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Einstein Content Recommendations",
+    "description" : null,
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/einstein-decisions/evergage-template.json
+++ b/einstein-decisions/evergage-template.json
@@ -2,5 +2,6 @@
     "name" : "Einstein Decisions",
     "description" : "",
     "imageUrl" : null,
-    "category" : null
-  }
+    "category" : null,
+    "channel" : "Web"
+}

--- a/einstein-product-recommendations/evergage-template.json
+++ b/einstein-product-recommendations/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Einstein Product Recommendations",
-  "description" : null,
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Einstein Product Recommendations",
+    "description" : null,
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/exit-intent-popup-with-email-capture/evergage-template.json
+++ b/exit-intent-popup-with-email-capture/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Exit Intent Pop-Up with Email Capture",
-  "description" : "",
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Exit Intent Pop-Up with Email Capture",
+    "description" : "",
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/exit-intent-popup/evergage-template.json
+++ b/exit-intent-popup/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Exit Intent Pop-Up",
-  "description" : "",
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Exit Intent Pop-Up",
+    "description" : "",
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/google-analytics-segment-push/evergage-template.json
+++ b/google-analytics-segment-push/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Google Analytics Segment Push",
-  "description" : null,
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Google Analytics Segment Push",
+    "description" : null,
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/infobar-with-cta/evergage-template.json
+++ b/infobar-with-cta/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Infobar With Call-To-Action",
-  "description" : "",
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Infobar With Call-To-Action",
+    "description" : "",
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/infobar-with-user-attribute-and-cta/evergage-template.json
+++ b/infobar-with-user-attribute-and-cta/evergage-template.json
@@ -2,5 +2,6 @@
     "name" : "Infobar With User Attribute and Call-To-Action",
     "description" : "",
     "imageUrl" : null,
-    "category" : null
-  }
+    "category" : null,
+    "channel" : "Web"
+}

--- a/manual-promotion-selector/evergage-template.json
+++ b/manual-promotion-selector/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Manual Promotion Selector",
-  "description" : "",
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Manual Promotion Selector",
+    "description" : "",
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/redirect/evergage-template.json
+++ b/redirect/evergage-template.json
@@ -1,6 +1,7 @@
 {
-  "name" : "Redirect",
-  "description" : null,
-  "imageUrl" : null,
-  "category" : null
+    "name" : "Redirect",
+    "description" : null,
+    "imageUrl" : null,
+    "category" : null,
+    "channel" : "Web"
 }

--- a/slide-in-with-cta/evergage-template.json
+++ b/slide-in-with-cta/evergage-template.json
@@ -2,5 +2,6 @@
     "name" : "Slide-In with Call-To-Action",
     "description" : "",
     "imageUrl" : null,
-    "category" : null
-  }
+    "category" : null,
+    "channel" : "Web"
+}


### PR DESCRIPTION
# Description

Adds 'Web' channel type to all web/currently existing global templates. Also fixed some indention.

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000rwpvUYAQ/view

## How to test

Format of the channel type string should match one listed in Template Channel here: https://github.com/evergage/evergage-product/blob/0c72b61585574a85a1beafa54d16ec61af3cd5d2/analytics/frontend/packages/state/src/slices/template-editor/template-editor.ts#L26

Once merged, we will test to make sure that all "Web" channel global templates will show up on the Web Global Templates list screen that currently exists on [feature-triggered-campaigns-1](https://github.com/evergage/evergage-product/blob/feature-triggered-campaigns-1/analytics/frontend/packages/ui-common/src/modules/templates/GlobalTemplatesList.tsx).
