### PR TITLE
@W-11071657@ Bug | Redirect template mistakenly sending impressions upon early return (aka early exit)

### DIFF
--- a/redirect/client.js
+++ b/redirect/client.js
@@ -1,47 +1,85 @@
 (function() {
 
-    function apply(context, template) {
+    /**
+     * @function isEditorFramePresent
+     * @returns {boolean}
+     * @description Return true when IS Launcher element is present
+     */
+    function isEditorFramePresent() {
+        return (window.frameElement || {}).id === "siteEditorFrame";
+    }
 
-        /** Prevent redirect from occurring while in either the Template Editor or Campaign Editor. */
-        if ((window.frameElement || {}).id === "siteEditorFrame") {
-            return;
-        }
-
+    /**
+     * @function shouldPreventRedirect
+     * @param {Object} context
+     * @returns {boolean}
+     * @description Return true if the execution of the redirect should be prevented
+     */
+    function shouldPreventRedirect(context) {
         const currentPage = window.location.hostname + window.location.pathname.replace(/\/$/, "");
         const targetPage = context.targetPageUrl.replace(/http(s)?\:\/\//, "");
         const redirectPage = context.redirectUrl.replace(/http(s)?\:\/\//, "");
-        if ((context.targetPageUrl && context.redirectUrl) &&
-            (currentPage !== targetPage && currentPage === redirectPage)) {
-            return;
-        }
+        return (context.targetPageUrl && context.redirectUrl) && (currentPage !== targetPage && currentPage === redirectPage);
+    }
 
-        return new Promise((resolve, reject) => {
-            SalesforceInteractions.cashDom("body").css("visibility", "hidden");
+    /**
+     * @function runTemplateExperience
+     * @param {Object} context
+     * @returns {Promise}
+     * @description Handle
+     */
+    function runTemplateExperience(context) {
+        return new Promise((resolve) => {
+            if (context.userGroup !== "Control") {
+                SalesforceInteractions.cashDom("body").css("visibility", "hidden");
 
-            SalesforceInteractions.mcis.sendStat({
-                campaignStats: [
-                    {
-                        control: false,
+                SalesforceInteractions.mcis.sendStat({
+                    campaignStats: [{
+                        control: context.userGroup === "Control",
                         experienceId: context.experience,
                         stat: "Impression"
-                    }
-                ]
-            });
+                    }]
+                });
 
-            context.paramsForRedirect = (context.maintainQueryParams && window.location.href.match(/\?.*/))
-                ? window.location.href.match(/\?.*/)[0]
-                : "";
+                context.paramsForRedirect = (context.maintainQueryParams && window.location.href.match(/\?.*/))
+                    ? window.location.href.match(/\?.*/)[0]
+                    : "";
 
-            window.location.href = context.redirectUrl + context.paramsForRedirect;
+                window.location.href = context.redirectUrl + context.paramsForRedirect;
+            } else {
+                resolve();
+            }
         });
     }
 
-    function reset(context, template) {
+    function apply(context, template) {
 
+        /** Prevent redirect from occurring while in either the Template Editor or Campaign Editor. */
+        if (isEditorFramePresent()) {
+            return;
+        }
+
+        if (shouldPreventRedirect(context)) {
+            return new Promise((resolve) => false && resolve());
+        }
+
+        return runTemplateExperience(context);
     }
 
-    function control() {
+    function reset(context, template) {
+        // Purposefully left empty
+    }
 
+    function control(context) {
+        if (isEditorFramePresent()) {
+            return;
+        }
+
+        if (shouldPreventRedirect(context)) {
+            return new Promise((resolve) => false && resolve());
+        }
+
+        return runTemplateExperience(context);
     }
 
     registerTemplate({


### PR DESCRIPTION
# Description

This PR changes the Redirect Global Template such that impression stats will not be sent when the template's `apply` function returns early. Additionally, the `control` function has been implemented to correctly track stats for the control group.

## Related Issues/Tickets

GUS: [W-11071657](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000vx6MnYAI/view)

## How to test
_TODO_ 🙃 

#### Template:
- You can view the demo template in `training:amask`, **template name: TEMPLATE_NAME**.

#### Campaign:
- You can view the demo campaign using this template in `training:amask`, **campaign name: CAMPAIGN_NAME**
_Note: you will need to force the SDK using this URL: https://cdn.evgnet.com/beacon/training/amask/scripts/evergage.min.js_

<!-- Steps for how to test your changes -->

### Things to check for:
* **Template-specific documentation**: Is there sufficient information for a Template Developer to use the Global Template and customize it for their own use?
* **FlickerDefender**: Is the page being fully hidden until the following page?
* **Campaign stats tracking:** Do impression stats and click stats fire for both the Control and Test experience?
