### PR TITLE
@w-13030026-fixing text for include segment

### DIFF
--- a/journey-builder-trigger/template.ts
+++ b/journey-builder-trigger/template.ts
@@ -123,8 +123,7 @@ export class JourneyBuilderTriggerPayload {
     additionalRecipe: RecipeReference;
 
     @title("Include User Segments")
-    @subtitle(`After you select segments, create an Additional_Segment field in the event data extension in 
-        Marketing Cloud.`)
+    @subtitle(`After you select segments, create a Segments field in the event data extension in Marketing Cloud.`)
     includeSegments: boolean = false;
 
     @title(" ")


### PR DESCRIPTION
# Description

Changed description (@subtitle) for the "Include User Segments" field. Replace an incorrect reference  "Additional_Segment" column with "Segments".

## Related Issues/Tickets

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001PNoYLYA1/view


## How to test

#### Template:
- You can view the demo template in account:dataset, **template name: TEMPLATE_NAME**.

#### Campaign:
- You can view the demo campaign using this template in account:dataset, **campaign name: CAMPAIGN_NAME**
_Note: you will need to force the SDK using this URL: SDK_URL_

<!-- Steps for how to test your changes -->

### Things to check for:
* **Visuals:** Does it look good across different client sites? To test this, you can copy, paste, and run this snippet in the JS console: GITHUB_GIST (see [template snippet](https://gist.github.com/nriserEG/fcfe7ab7e04d51dbf9cb19fc0476d474))
* **Mobile/smaller screen responsiveness:** Does the Template generally look good on smaller screens?
* **WCAG compliant:** Does the template contain ARIA attributes and/or use semantic elements for web accessibility? You can use the [WAVE Chrome extension tool](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) for a quick check.
* **Template-specific documentation**: Is there sufficient information for a Template Developer to use the Global Template and customize it for their own use?
* **FlickerDefender**: Is the page being fully hidden until the following page?
* **Campaign stats tracking:** Do impression stats and click stats fire for both the Control and Test experience?
